### PR TITLE
Refactor Health checker

### DIFF
--- a/healthcheck/Healthchecker.go
+++ b/healthcheck/Healthchecker.go
@@ -1,5 +1,5 @@
 package healthcheck
 
-type HealthChecker interface {
+type HealthCheckerReplier interface {
 	Run() error
 }

--- a/healthcheck/healtcheck.go
+++ b/healthcheck/healtcheck.go
@@ -7,14 +7,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type healthChecker struct {
+type healthCheckerReplier struct {
 	config      *config.HealthCheckConfig
 	serviceName string
 	socket      client.Client
 }
 
-// InitHealthChecker inits a health checker for the given serviceName
-func InitHealthChecker(serviceName string) HealthChecker {
+// InitHealthCheckerReplier inits a health checker replier for the given serviceName
+func InitHealthCheckerReplier(serviceName string) HealthCheckerReplier {
 	cfg := config.GetHealthCheckConfig()
 	address := fmt.Sprintf("%s:%v", serviceName, cfg.Port)
 	socket := client.NewSocket(
@@ -25,7 +25,7 @@ func InitHealthChecker(serviceName string) HealthChecker {
 		),
 	)
 
-	return &healthChecker{
+	return &healthCheckerReplier{
 		config:      cfg,
 		serviceName: serviceName,
 		socket:      socket,
@@ -33,16 +33,16 @@ func InitHealthChecker(serviceName string) HealthChecker {
 }
 
 // Run triggers the health check routine. This routine listen for heartbeats in a given port and replies them with an ACK message
-func (hc *healthChecker) Run() error {
+func (hc *healthCheckerReplier) Run() error {
 	err := hc.socket.StartListener()
 	if err != nil {
-		log.Errorf("Lichita error starteando listener %v", err)
+		log.Errorf("error starting listener: %v", err)
 		return err
 	}
 
 	messageHandler, err := hc.socket.AcceptNewConnections()
 	if err != nil {
-		log.Errorf("Lichita error accept connections %v", err)
+		log.Errorf("error accepting connections: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
Minor changes about log messages and the name of the struct, I think that is better called it `Health Checker Replier`, so in the other repo we can distinguish between the service and the repliers